### PR TITLE
タスク用issueテンプレートの追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/task_report.yml
+++ b/.github/ISSUE_TEMPLATE/task_report.yml
@@ -1,0 +1,38 @@
+name: 💡 タスク管理用issue
+description: タスク管理の際に使用する
+labels: ["task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        以下の情報を記入してください。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: タスクの概要や目的、実装する意図を記載する
+      placeholder: 例）〜のため機能を追加する
+    validations:
+      required: true
+  
+  - type: dropdown
+    id: category
+    attributes:
+      label: タスクのカテゴリー
+      description: 不具合修正の場合：bug 既存のデザインを変更する場合：design 新規で機能やセクションを追加する場合：feature
+      multiple: true
+      options:
+        - bug
+        - design
+        - feature
+      validations:
+        required: true
+  
+  - type: textarea
+    id: todo
+    attributes:
+      label: TODO
+      description: タスクのTODOを記載する
+    validations:
+      required: true

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,12 @@
+policy:
+  - template: ["task_report.yml"]
+    section:
+      - id: ["category"]
+        block-list: []
+        label:
+          - name: bug
+            keys: ["bug"]
+          - name: design
+            keys: ["design"]
+          - name: feature
+            keys: ["feature"]

--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -1,0 +1,34 @@
+name: Issue labeler
+on:
+  issues:
+    types: [ opened ]
+
+permissions:
+  contents: read
+
+jobs:
+  label-component:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      issues: write
+      
+    strategy:
+      matrix:
+        template: [ task_report.yml ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      - name: Set labels based on component field
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 概要
issue
https://github.com/zatty-5118/blog/issues/12

### やったこと

- task用のissueテンプレートを追加
- ラベル自動付与のactionを追加
- ラベルの設定を追加