### PR TITLE
タスク用issueテンプレートの追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/task_report.yml
+++ b/.github/ISSUE_TEMPLATE/task_report.yml
@@ -22,12 +22,11 @@ body:
       label: タスクのカテゴリー
       description: 不具合修正の場合：bug 既存のデザインを変更する場合：design 新規で機能やセクションを追加する場合：feature
       multiple: true
+      required: true
       options:
         - bug
         - design
         - feature
-      validations:
-        required: true
   
   - type: textarea
     id: todo


### PR DESCRIPTION
概要
issue
https://github.com/zatty-5118/blog/issues/12

やったこと
task用のissueテンプレートを追加
ラベル自動付与のactionを追加
ラベルの設定を追加